### PR TITLE
Fix: Improve error handling for personnel deletion

### DIFF
--- a/src/pages/Personnel.tsx
+++ b/src/pages/Personnel.tsx
@@ -120,9 +120,13 @@ export function Personnel() {
       await personnelAPI.delete(deleteConfirm.personnel.id)
       setPersonnel(prev => prev.filter(p => p.id !== deleteConfirm.personnel!.id))
       toast.success('Personnel deleted successfully')
-    } catch (error) {
+    } catch (error: any) {
       console.error('Error deleting personnel:', error)
-      toast.error('Failed to delete personnel')
+      if (error && error.code === '23503') {
+        toast.error('This person cannot be deleted as they are referenced in other records (e.g., as a proposer of a motion).')
+      } else {
+        toast.error('Failed to delete personnel.')
+      }
     } finally {
       setDeleteConfirm({ isOpen: false, personnel: null })
     }


### PR DESCRIPTION
This commit addresses an issue where deleting personnel would fail without a clear error message if the person was referenced in other records (e.g., as a proposer of a motion).

This was caused by an `ON DELETE RESTRICT` foreign key constraint in the database.

This commit improves the user experience by:
1.  Catching the specific Postgres error for foreign key violations (`23503`) in the `confirmDelete` function in `src/pages/Personnel.tsx`.
2.  Displaying a user-friendly toast notification explaining why the deletion failed.